### PR TITLE
ISBN match disable configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ function SRADedupe(settings) {
 			threadLimit: 50, // How many parallel threads to allow when comparing
 			progressThrottle: 100, // Throttle progress reporting to this value
 		},
+		match: {
+			isbn: true,		// Turn off ISBN matching, if you find it creates false positives e.g. with collected works.
+		},
 	});
 
 
@@ -87,13 +90,15 @@ function SRADedupe(settings) {
 		// This comparison only works if each side has a 'perfect' ISBN - i.e. /^\s*[0-9\.\-\s]+\s*$/
 		// This test uses the certainty that ISBN numbers are unlikely to be mangled
 		// If both (de-noised) ISBNs match the ref is declared a dupe, if not they are declared a NON dupe
-		var r1Isbn = dedupe.getNumeric(ref1.isbn);
-		var r2Isbn = dedupe.getNumeric(ref2.isbn);
-		if (r1Isbn !== false && r2Isbn !== false) { // Can compare ISBNs
-			return {isDupe: r1Isbn == r2Isbn, reason: 'isbn'}; // If direct match its a dupe, if not its NOT a dupe
+		if(dedupe.settings.match.isbn){
+			var r1Isbn = dedupe.getNumeric(ref1.isbn);
+			var r2Isbn = dedupe.getNumeric(ref2.isbn);
+			if(r1Isbn !== false && r2Isbn !== false){ // Can compare ISBNs
+				return {isDupe: r1Isbn == r2Isbn, reason: 'isbn'}; // If direct match its a dupe, if not its NOT a dupe
+			}
 		}
 		// }}}
-
+		
 		// Stage 6 - Comparison of title + authors via string distance checking {{{
 		var r1Title = ref1.title.toLowerCase();
 		var r2Title = ref2.title.toLowerCase();

--- a/test/data/isbn-false-dupe.json
+++ b/test/data/isbn-false-dupe.json
@@ -1,0 +1,39 @@
+[
+{
+  "recNumber": "2000",
+  "title": "The construct of the multisensory temporal binding window and its dysregulation in developmental disabilities",
+  "journal": "Neuropsychologia",
+  "address": "Vanderbilt Brain Institute, Vanderbilt University, 465 21st Avenue South, Nashville, TN 37232, USA; Department of Hearing & Speech Sciences, Vanderbilt University, Nashville, TN, USA; Department of Psychology, Vanderbilt University, Nashville, TN, USA; Department of Psychiatry, Vanderbilt University, Nashville, TN, USA. Electronic address: mark.wallace@vanderbilt.edu.\rDepartment of Psychology, University of Toronto, Toronto, ON, Canada.",
+  "type": "journalArticle",
+  "authors": "Wallace, M. T.,Stevenson, R. A.",
+  "pages": "105-23",
+  "volume": "64",
+  "isbn": "0028-3932",
+  "abstract": "Behavior, perception and cognition are strongly shaped by the synthesis of information across the different sensory modalities. Such multisensory integration often results in performance and perceptual benefits that reflect the additional information conferred by having cues from multiple senses providing redundant or complementary information. The spatial and temporal relationships of these cues provide powerful statistical information about how these cues should be integrated or \"bound\" in order to create a unified perceptual representation. Much recent work has examined the temporal factors that are integral in multisensory processing, with many focused on the construct of the multisensory temporal binding window - the epoch of time within which stimuli from different modalities is likely to be integrated and perceptually bound. Emerging evidence suggests that this temporal window is altered in a series of neurodevelopmental disorders, including autism, dyslexia and schizophrenia. In addition to their role in sensory processing, these deficits in multisensory temporal function may play an important role in the perceptual and cognitive weaknesses that characterize these clinical disorders. Within this context, focus on improving the acuity of multisensory temporal function may have important implications for the amelioration of the \"higher-order\" deficits that serve as the defining features of these disorders.",
+  "notes": "1873-3514\rWallace, Mark T\rStevenson, Ryan A\rR21 CA183492/CA/NCI NIH HHS/United States\rR34 DC010927/DC/NIDCD NIH HHS/United States\rJournal Article\rReview\rEngland\rNeuropsychologia. 2014 Nov;64:105-23. doi: 10.1016/j.neuropsychologia.2014.08.005. Epub 2014 Aug 13.",
+  "custom2": "PMC4326640",
+  "custom6": "NIHMS632840",
+  "year": "2014",
+  "date": "Nov",
+  "keywords": "Auditory Perception/*physiology,Cognition/*physiology,Cues,Developmental Disabilities/*psychology,Humans,Reaction Time/physiology,Visual Perception/*physiology,*Autism,*Crossmodal,*Dyslexia,*Multisensory,*Schizophrenia,*Temporal"
+},
+{
+  "recNumber": "2001",
+  "title": "Are individual differences in speech reception related to individual differences in cognitive ability? A survey of twenty experimental studies with normal and hearing-impaired adults",
+  "journal": "Neuropsychologia",
+  "address": "Vanderbilt Brain Institute, Vanderbilt University, 465 21st Avenue South, Nashville, TN 37232, USA; Department of Hearing & Speech Sciences, Vanderbilt University, Nashville, TN, USA; Department of Psychology, Vanderbilt University, Nashville, TN, USA; Department of Psychiatry, Vanderbilt University, Nashville, TN, USA. Electronic address: mark.wallace@vanderbilt.edu.\rDepartment of Psychology, University of Toronto, Toronto, ON, Canada.",
+  "type": "journalArticle",
+  "authors": "Wallace, M. T.,Stevenson, R. A.",
+  "pages": "105-23",
+  "volume": "64",
+  "isbn": "0028-3932",
+  "abstract": "Behavior, perception and cognition are strongly shaped by the synthesis of information across the different sensory modalities. Such multisensory integration often results in performance and perceptual benefits that reflect the additional information conferred by having cues from multiple senses providing redundant or complementary information. The spatial and temporal relationships of these cues provide powerful statistical information about how these cues should be integrated or \"bound\" in order to create a unified perceptual representation. Much recent work has examined the temporal factors that are integral in multisensory processing, with many focused on the construct of the multisensory temporal binding window - the epoch of time within which stimuli from different modalities is likely to be integrated and perceptually bound. Emerging evidence suggests that this temporal window is altered in a series of neurodevelopmental disorders, including autism, dyslexia and schizophrenia. In addition to their role in sensory processing, these deficits in multisensory temporal function may play an important role in the perceptual and cognitive weaknesses that characterize these clinical disorders. Within this context, focus on improving the acuity of multisensory temporal function may have important implications for the amelioration of the \"higher-order\" deficits that serve as the defining features of these disorders.",
+  "notes": "1873-3514\rWallace, Mark T\rStevenson, Ryan A\rR21 CA183492/CA/NCI NIH HHS/United States\rR34 DC010927/DC/NIDCD NIH HHS/United States\rJournal Article\rReview\rEngland\rNeuropsychologia. 2014 Nov;64:105-23. doi: 10.1016/j.neuropsychologia.2014.08.005. Epub 2014 Aug 13.",
+  "custom2": "PMC4326640",
+  "custom6": "NIHMS632840",
+  "year": "2014",
+  "date": "Nov",
+  "keywords": "Auditory Perception/*physiology,Cognition/*physiology,Cues,Developmental Disabilities/*psychology,Humans,Reaction Time/physiology,Visual Perception/*physiology,*Autism,*Crossmodal,*Dyslexia,*Multisensory,*Schizophrenia,*Temporal"
+}
+
+]

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,24 @@
+var _ = require('lodash');
+var expect = require('chai').expect;
+
+describe('dedupe.compare()', function() {
+
+	it('should match on ISBN duplicates when configured ON by default', function() {
+        var dedupe = require('..')();
+		expect(dedupe.compare({title: 'my paper', isbn: '978-0553380958'}, {title: 'another paper', isbn: '978-0553380958'})).to.deep.equal({isDupe: true, reason: 'isbn'});
+		expect(dedupe.compare({title: 'my paper', isbn: '978-0563380958'}, {title: 'another paper', isbn: '978-0553380958'})).to.deep.equal({isDupe: false, reason: 'isbn'});
+	});
+
+	it('should not match on ISBN duplicates when configured OFF', function() {
+        var dedupe = require('..')({match:{isbn:false}});
+        // title different but same ISBN, now exhausts the search
+        expect(dedupe.compare({title: 'my paper', isbn: '978-0553380958'}, {title: 'another paper', isbn: '978-0553380958'})).to.deep.equal({isDupe: false, reason: 'EXHAUSTED'});
+        // Different ISBN still prevents match
+        expect(dedupe.compare({title: 'my paper', isbn: '978-0563380958'}, {title: 'another paper', isbn: '978-0553380958'})).to.deep.equal({isDupe: false, reason: 'isbn'});
+        // Match title with same ISBN (regression test)
+		expect(dedupe.compare({title: 'another paper', isbn: '978-0553380958'}, {title: 'another paper', isbn: '978-0553380958'})).to.deep.equal({isDupe: true, reason: 'title+authors'});
+        // still do not match same title with different ISBN
+		expect(dedupe.compare({title: 'my paper', isbn: '978-0563380958'}, {title: 'my paper', isbn: '978-0553380958'})).to.deep.equal({isDupe: false, reason: 'isbn'});
+	});
+	
+});


### PR DESCRIPTION
Hi,

I have found sometimes the ISBN match creates false positives, I think due to articles being published in "collections" of various sorts where the ISBN is for the overall group.

I wanted to be able to turn it on/off, so I have added a proposed configuration section called "match" with this feature enabled by default. I thought `match.isbn` might be better than something specific like `ignoreISBN`, as it could lead on to adding a list to allow fine-grained control over the matches, possibly in future.

I have written a test with positive, negative and regression cases. I also included a real-world example (one of many), and was going to use this in the tests but when I saw the ISBN test example, I just continued in that style of made-up simpler attributes. I've left the JSON file for reference.

Note I have not removed the corresponding ISBN "mismatch", as I don't think that was causing false negatives. The test checks for ISBN mismatch proving no-match.

I know just turning ISBN match off altogether is a shame as there is value in the attribute. I'd rather still match it but then perhaps continue to check the title too. If the ISBN is matched, but the title is totally different, then it could discard the ISBN match rather than returning immediately at the ISBN match (this represents my example case). However I thought this contextual perhaps would be generalised to a more probabilistic approach, where each match might add a weighting which is summed, thresholded etc. but that would require training hyperparameters and it all gets complicated!

thanks