### PR TITLE
DOI match-disable configuration

### DIFF
--- a/i3.json
+++ b/i3.json
@@ -57,7 +57,6 @@
       "title": "Field to change when marking as duplicate",
       "showIf": "action == 'mark'",
       "type": "string",
-      "advanced": true,
       "default": "caption"
     }
   }


### PR DESCRIPTION
Hi,

As I mentioned in my ISBN PR I have found the DOI match can also create false-positive duplicates in collections.

So I have added a similar config to switch this match on/off, and a simple test, copied from the existing DOI test, but changed to "no match" when off.

This seemed simpler than the ISBN, but let me know if I've missed anything.

thanks.